### PR TITLE
Added minor modifications to the yaml file

### DIFF
--- a/examples/Author_YYYY_FirstTitleWord_Page_fignr_identifier.yaml
+++ b/examples/Author_YYYY_FirstTitleWord_Page_fignr_identifier.yaml
@@ -15,10 +15,10 @@ curator:
     orcid: https://orcid.org/0000-0002-9686-3948
     digitized: 2021-06-01 # YYYY-MM-DD
     
-figure description: #This section will be updated by module `CV`
+figure description: #This section will be updated by module `svgdigitizer.electrochemistry.cv.CV`
     version: 1
     linked measurements: null # FTIR, SXRD, Ring Disc - indicate if any other operando methods were shown in the same plot, which is linked to the data
-    comment: # Add whatever you think is important to understand the data
+    comment: # Add whatever you think is important to understand the data. This will be updated by the `svgdigitizer.electrochemistry.cv.CV` module and takes the comment from the svg file.
 
 electrochemical system:
     version: 1
@@ -34,7 +34,7 @@ electrochemical system:
     electrolyte:
         type: aq # aqueous = aq, non-aqueous=naq
         components: # create as many components as necessary. A simple electrolyte consists of two components, i.e., H2SO4 and water
-            - name: NaCl  # can be trivia name, sum formula, etc
+            - name: NaCl # can be trivia name, sum formula, etc
               concentration:
                   value: 0.1
                   unit: M #[M, mM, µM, g kg-1, ...]
@@ -84,7 +84,7 @@ electrochemical system:
             shape: wire
         working electrode:
             material: Ni
-            crystallographic orientation: 111 # hkl, 100, 110, poly
+            crystallographic orientation: '111' # 'hkl', '100', '110', 'poly'. Force string with ''. Otherwise the zeroes will be stripped from '0001'
             source:
                 supplier: null
                 LOT: 

--- a/examples/electrochemical_system.yaml
+++ b/examples/electrochemical_system.yaml
@@ -64,7 +64,7 @@ electrochemical system:
             shape: wire
         working electrode:
             material: Ni
-            crystallographic orientation: 111 # hkl, 100, 110, poly
+            crystallographic orientation: '111' # 'hkl', '100', '110', 'poly'. Force string with ''. Otherwise the zeroes will be stripped from '0001'
             source:
                 supplier: null
                 LOT: 

--- a/examples/figure_description.yaml
+++ b/examples/figure_description.yaml
@@ -1,6 +1,6 @@
 # This file provides additional information on a figure from a publication containing electrochemical data.
     
-figure description: #This section will be updated by module `CV`
+figure description: #This section will be updated by module `svgdigitizer.electrochemistry.cv.CV`
     version: 1
     linked measurements: null # FTIR, SXRD, Ring Disc - indicate if any other operando methods were shown in the same plot, which is linked to the data
-    comment: # Add whatever you think is important to understand the data
+    comment: # Add whatever you think is important to understand the data. This will be updated by the `svgdigitizer.electrochemistry.cv.CV` module and takes the comment from the svg file.


### PR DESCRIPTION
In the electrochemical_system the crystallograhic orientation shoulf be provided as a string, otherwise the zeroes in 0001  will be stripped.
Extended the information on Figure description that the comment field will be updated by the newest version of the svgdigitizer