### PR TITLE
Improve compatability with echemdb database

### DIFF
--- a/examples/objects/system.yaml
+++ b/examples/objects/system.yaml
@@ -108,7 +108,7 @@ electrodes:
       model: MSE Shott
       url: http://some.url.to.a.pdf.html
     description: Home made RHE.
-    components:
+    components: # Only applies if the reference electrode is not from a supplier and usually is of type "quasi reference electrode".
       - name: Pt
         type: wire
         shape:

--- a/examples/objects/system.yaml
+++ b/examples/objects/system.yaml
@@ -108,7 +108,7 @@ electrodes:
       model: MSE Shott
       url: http://some.url.to.a.pdf.html
     description: Home made RHE.
-    components: # Only applies if the reference electrode is not from a supplier and usually is of type "quasi reference electrode".
+    components:
       - name: Pt
         type: wire
         shape:

--- a/schemas/svgdigitizer.json
+++ b/schemas/svgdigitizer.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-06/schema#",
-    "$id": "https://raw.githubusercontent.com/echemdb/metadata-schema/main/schemas/svgdigitizer.json #",
+    "$id": "https://raw.githubusercontent.com/echemdb/metadata-schema/main/schemas/svgdigitizer.json#",
     "allOf": [{ "$ref": "#/definitions/Svgdigitizer" }],
     "definitions": {
         "Svgdigitizer": {
@@ -31,7 +31,6 @@
             },
             "required": [
                 "curation",
-                "experimental",
                 "source",
                 "system"
             ],

--- a/schemas/system.json
+++ b/schemas/system.json
@@ -28,7 +28,6 @@
                 }
             },
             "required": [
-                "electrochemical cell",
                 "electrodes",
                 "electrolyte",
                 "type"

--- a/schemas/system/electrode.json
+++ b/schemas/system/electrode.json
@@ -13,7 +13,8 @@
             ],
             "properties": {
                 "name": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "A unique identifier."
                 },
                 "function": {
                     "type": "string",

--- a/schemas/system/electrolyte.json
+++ b/schemas/system/electrolyte.json
@@ -74,6 +74,9 @@
                 },
                 "comment": {
                     "type": "string"
+                },
+                "pressure": {
+                    "$ref": "../general/quantity.json"
                 }
             },
             "required": [

--- a/schemas/system/electrolyte.json
+++ b/schemas/system/electrolyte.json
@@ -7,6 +7,9 @@
             "type": "object",
             "title": "Electrolyte",
             "additionalProperties": false,
+            "required": [
+                "type"
+            ],
             "properties": {
                 "type": {
                     "type": "string",

--- a/schemas/system/electrolyte.json
+++ b/schemas/system/electrolyte.json
@@ -15,7 +15,8 @@
                     "type": "string",
                     "oneOf": [
                         {"const": "aqueous", "description": "The solvent is water."},
-                        {"const": "non-aqueous", "description": "The solvent is non-aqueous, i.e., is an ionic liquid or another organic compound."},
+                        {"const": "ionic liquid", "description": "The solvent is an ionic liquid."},
+                        {"const": "non-aqueous", "description": "The solvent is non-aqueous other than an ionic liquid, i.e., an organic compound."},
                         {"const": "solid", "description": "A solid electrolyte."}
                     ]
                 },

--- a/schemas/system/electrolyte.json
+++ b/schemas/system/electrolyte.json
@@ -124,6 +124,9 @@
                 },
                 "refinement": {
                     "type": "string"
+                },
+                "quality": {
+                    "type": "string"
                 }
             },
             "title": "ComponentSource"

--- a/schemas/system/electrolyte.json
+++ b/schemas/system/electrolyte.json
@@ -108,6 +108,9 @@
                 "url": {
                     "$ref": "../general/url.json",
                     "description": "A url with further details on the electrolyte container."
+                },
+                "total ionic conductivity": {
+                    "$ref": "../general/quantity.json"
                 }
             },
             "title": "ComponentPurity"

--- a/schemas/system/electrolyte.json
+++ b/schemas/system/electrolyte.json
@@ -140,6 +140,12 @@
                 },
                 "total ion conductivity": {
                     "$ref": "../general/quantity.json"
+                },
+                "value": {
+                    "type": "number"
+                },
+                "unit": {
+                    "type": "string"
                 }
             },
             "title": "SuppliedPurity"

--- a/schemas/system/electrolyte.json
+++ b/schemas/system/electrolyte.json
@@ -166,7 +166,7 @@
             "additionalProperties": false,
             "properties": {
                 "value": {
-                    "type": "integer"
+                    "type": "number"
                 },
                 "uncertainty": {
                     "type": "number"


### PR DESCRIPTION
* removed key instrumentation to be mandatory in the svgdigitizer schema, since this is in most cases generated during the conversion of the SVG to the datapackage.