### PR TITLE
Remove supplied purity and use single purity schema for anything

### DIFF
--- a/doc/news/dell-suppl-purity.rst
+++ b/doc/news/dell-suppl-purity.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Added <news item>.
+
+**Changed:**
+
+* Changed <news item>.
+
+**Removed:**
+
+* Removed <news item>.
+
+**Fixed:**
+
+* Fixed <news item>.
+
+**Deprecated:**
+
+* Deprecated <news item>.
+
+**Performance:**
+
+* Improved <news item>.

--- a/doc/news/dell-suppl-purity.rst
+++ b/doc/news/dell-suppl-purity.rst
@@ -1,23 +1,8 @@
-**Added:**
-
-* Added <news item>.
-
 **Changed:**
 
-* Changed <news item>.
+* Changed `supplied purity` to `purity` and use one `purity` schema for all `purity` keys.
 
-**Removed:**
+**Removed**
 
-* Removed <news item>.
-
-**Fixed:**
-
-* Fixed <news item>.
-
-**Deprecated:**
-
-* Deprecated <news item>.
-
-**Performance:**
-
-* Improved <news item>.
+* Removed `supplied purity` in favor of `purity`.
+*

--- a/examples/file_schemas/autotag.yaml
+++ b/examples/file_schemas/autotag.yaml
@@ -75,7 +75,7 @@ system:
         source:
           supplier: company name # Company name, organic chemistry III - Uni Ulm
           LOT: 155464A # LOT number
-          supplied purity:
+          purity:
             grade: 5N # analytical grade, 5N, etc
             total organic carbon:
               value: 3

--- a/examples/file_schemas/svgdigitizer.yaml
+++ b/examples/file_schemas/svgdigitizer.yaml
@@ -61,7 +61,7 @@ system:
         source:
           supplier: company name # Company name, organic chemistry III - Uni Ulm
           LOT: 155464A # LOT number
-          supplied purity:
+          purity:
             grade: 5N # analytical grade, 5N, etc
             total organic carbon:
               value: 3

--- a/examples/objects/system.yaml
+++ b/examples/objects/system.yaml
@@ -17,7 +17,7 @@ electrolyte:
       source:
         supplier: Company name # Company name, organic chemistry III - Uni Ulm
         LOT: ABC123 # LOT number
-        supplied purity:
+        purity:
           grade: 5N # analytical grade, 5N, etc
           total organic carbon:
             value: 3

--- a/schemas/general/purity.json
+++ b/schemas/general/purity.json
@@ -1,0 +1,43 @@
+{
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$id": "https://raw.githubusercontent.com/echemdb/metadata-schema/main/schemas/general/purity.json",
+    "allOf": [{ "$ref": "#/definitions/Purity" }],
+    "definitions": {
+        "Purity": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "grade": {
+                    "type": "string"
+                },
+                "total organic carbon": {
+                    "$ref": "../general/quantity.json"
+                },
+                "total ion conductivity": {
+                    "$ref": "../general/quantity.json"
+                },
+                "value": {
+                    "type": "number"
+                },
+                "unit": {
+                    "type": "string"
+                },
+                "container": {
+                    "type": "string",
+                    "description": "An unambiguous name for the container."
+                },
+                "internal LOT": {
+                    "type": "string"
+                },
+                "url": {
+                    "$ref": "../general/url.json",
+                    "description": "A url with further details on the electrolyte container."
+                },
+                "refinement": {
+                    "type": "string"
+                }
+            },
+            "title": "Purity"
+        }
+    }
+}

--- a/schemas/system/electrode.json
+++ b/schemas/system/electrode.json
@@ -35,8 +35,14 @@
                 "geometric electrolyte contact area": {
                     "$ref": "../general/quantity.json"
                 },
+                "purity": {
+                    "$ref": "../general/purity.json"
+                },
                 "preparation procedure": {
                     "$ref": "#/definitions/ElectrodePreparation"
+                },
+                "shape": {
+                    "$ref": "#/definitions/Shape"
                 },
                 "source": {
                     "type": "object",
@@ -44,9 +50,6 @@
                 },
                 "type": {
                     "type": "string"
-                },
-                "shape": {
-                    "$ref": "#/definitions/Shape"
                 },
                 "material": {
                     "type": "string",
@@ -69,7 +72,7 @@
                     "type": "string"
                 },
                 "purity": {
-                    "$ref": "#/definitions/SourcePurity"
+                    "$ref": "../general/purity.json"
                 },
                 "model": {
                     "type":"string"
@@ -80,16 +83,6 @@
                 }
             },
             "title": "ElectrodeSource"
-        },
-        "SourcePurity": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "grade": {
-                    "type": "string"
-                }
-            },
-            "title": "SourcePurity"
         },
         "Shape": {
             "type": "object",

--- a/schemas/system/electrolyte.json
+++ b/schemas/system/electrolyte.json
@@ -64,7 +64,7 @@
                     "$ref": "#/definitions/ComponentSource"
                 },
                 "purity": {
-                    "$ref": "#/definitions/ComponentPurity"
+                    "$ref": "../general/purity.json"
                 },
                 "partial pressure": {
                     "$ref": "../general/quantity.json"
@@ -88,36 +88,6 @@
             ],
             "title": "ElectrolyteComponent"
         },
-        "ComponentPurity": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "refinement": {
-                    "type": "string"
-                },
-                "grade": {
-                    "type": "string"
-                },
-                "total organic carbon": {
-                    "$ref": "../general/quantity.json"
-                },
-                "container": {
-                    "type": "string",
-                    "description": "An unambiguous name for the container."
-                },
-                "internal LOT": {
-                    "type": "string"
-                },
-                "url": {
-                    "$ref": "../general/url.json",
-                    "description": "A url with further details on the electrolyte container."
-                },
-                "total ionic conductivity": {
-                    "$ref": "../general/quantity.json"
-                }
-            },
-            "title": "ComponentPurity"
-        },
         "ComponentSource": {
             "type": "object",
             "additionalProperties": false,
@@ -128,8 +98,8 @@
                 "LOT": {
                     "type": "string"
                 },
-                "supplied purity": {
-                    "$ref": "#/definitions/SuppliedPurity"
+                "purity": {
+                    "$ref": "../general/purity.json"
                 },
                 "refinement": {
                     "type": "string"
@@ -139,28 +109,6 @@
                 }
             },
             "title": "ComponentSource"
-        },
-        "SuppliedPurity": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "grade": {
-                    "type": "string"
-                },
-                "total organic carbon": {
-                    "$ref": "../general/quantity.json"
-                },
-                "total ion conductivity": {
-                    "$ref": "../general/quantity.json"
-                },
-                "value": {
-                    "type": "number"
-                },
-                "unit": {
-                    "type": "string"
-                }
-            },
-            "title": "SuppliedPurity"
         },
         "ElectrolyteContainer": {
             "type": "object",


### PR DESCRIPTION
The purity of the supplier was namen `supplied purity` and had different keys than the general `purity`. 