### PR TITLE
Add supplier or manufacturer to sources

### DIFF
--- a/doc/news/del-manufacturer.rst
+++ b/doc/news/del-manufacturer.rst
@@ -1,0 +1,3 @@
+**Added:**
+
+* Added `supplier` and/or `manufacturer` to the source of components, instruments, materials, etc.

--- a/schemas/experimental/instrumentation.json
+++ b/schemas/experimental/instrumentation.json
@@ -20,6 +20,9 @@
                 },
                 "model": {
                     "type": "string"
+                },
+                "supplier": {
+                    "type": "string"
                 }
             },
             "required": [

--- a/schemas/system/electrode.json
+++ b/schemas/system/electrode.json
@@ -80,6 +80,9 @@
                 "url": {
                     "$ref": "../general/url.json",
                     "description": "A url to a pdf or description of the electrode."
+                },
+                "supplier": {
+                    "type": "string"
                 }
             },
             "title": "ElectrodeSource"

--- a/schemas/system/electrolyte.json
+++ b/schemas/system/electrolyte.json
@@ -58,7 +58,7 @@
                         {"const": "acid", "description": "An acid added to the solvent."},
                         {"const": "base", "description": "A base added to the solvent."},
                         {"const": "gas", "description": "A gas passed through the solvent."},
-                        {"const": "solute", "description": "A solute added to the solvent, which is not a salt, acid, base, or a gas, i.e., water."}
+                        {"const": "solute", "description": "A solute added to the solvent, which is not a salt, acid, base or a gas, i.e., water."}
                     ]
                 },
                 "source": {
@@ -96,6 +96,9 @@
                 "supplier": {
                     "type": "string"
                 },
+                "manufacturer": {
+                    "type": "string"
+                },
                 "LOT": {
                     "type": "string"
                 },
@@ -117,7 +120,7 @@
             "properties": {
                 "description": {
                     "type": "string",
-                    "description": "The vessel in which the supplying electrolyte as prepared or stored before the measurment."
+                    "description": "The vessel in which the supplying electrolyte as prepared or stored before the measurement."
                 },
                 "components": {
                     "type": "array",


### PR DESCRIPTION
The source of a material, instrument, or component, ... can be allocated to a supplier or manufacturer, depending on what is more appropriate.