### PR TITLE
Keep unquoted YAML dates as strings when loading metadata

### DIFF
--- a/doc/news/fix-yaml-date-loading.rst
+++ b/doc/news/fix-yaml-date-loading.rst
@@ -1,0 +1,7 @@
+**Fixed:**
+
+* Fixed validation of YAML metadata containing unquoted dates (e.g.
+  ``date: 2021-07-09``): YAML files are now loaded with
+  ``MetadataYamlLoader``, which keeps dates and timestamps as plain strings
+  instead of ``datetime.date`` objects that fail validation of string-typed
+  schema fields (`#123 <https://github.com/echemdb/metadata-schema/issues/123>`_).

--- a/mdstools/schema/validate_examples.py
+++ b/mdstools/schema/validate_examples.py
@@ -51,9 +51,11 @@ import sys
 from pathlib import Path
 
 import jsonschema
-import yaml
 
-from mdstools.schema.validator import validate_instrument_references
+from mdstools.schema.validator import (
+    load_yaml_metadata,
+    validate_instrument_references,
+)
 
 
 def _load_generated_schema(schema_path: Path) -> dict:
@@ -147,7 +149,7 @@ def validate_objects():
             schema = _build_object_schema(parent, def_name)
 
         with open(example_path, "r", encoding="utf-8") as f:
-            data = yaml.safe_load(f)
+            data = load_yaml_metadata(f)
 
         errors = validate_data(data, schema)
         ref_errors = validate_instrument_references(data)
@@ -191,7 +193,7 @@ def validate_file_schemas():
 
         schema = _load_generated_schema(schema_path)
         with open(example_path, "r", encoding="utf-8") as f:
-            data = yaml.safe_load(f)
+            data = load_yaml_metadata(f)
 
         errors = validate_data(data, schema)
         ref_errors = validate_instrument_references(data)

--- a/mdstools/schema/validator.py
+++ b/mdstools/schema/validator.py
@@ -33,6 +33,7 @@ Three validation approaches are available:
 #  along with mdstools. If not, see <https://www.gnu.org/licenses/>.
 # ********************************************************************
 
+import datetime
 import importlib
 import json
 import urllib.request
@@ -314,8 +315,63 @@ def validate_instrument_references(data: Any) -> list:
 # ---------------------------------------------------------------------------
 
 
+def _dates_to_strings(value: Any) -> Any:
+    r"""Return ``value`` with dates and datetimes replaced by ISO strings.
+
+    PyYAML resolves unquoted YAML dates (e.g. ``date: 2021-07-09``) to
+    ``datetime.date`` objects, but the metadata schemas type dates as strings
+    (JSON Schema has no date type). Containers are rebuilt recursively.
+
+    EXAMPLES::
+
+        >>> import datetime
+        >>> from mdstools.schema.validator import _dates_to_strings
+        >>> _dates_to_strings({'date': datetime.date(2021, 7, 9)})
+        {'date': '2021-07-09'}
+
+        >>> _dates_to_strings([datetime.datetime(2021, 7, 9, 12, 30)])
+        ['2021-07-09T12:30:00']
+
+        >>> _dates_to_strings({'value': 298.15})
+        {'value': 298.15}
+
+    """
+    if isinstance(value, dict):
+        return {key: _dates_to_strings(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_dates_to_strings(item) for item in value]
+    if isinstance(value, (datetime.date, datetime.datetime)):
+        return value.isoformat()
+    return value
+
+
+def load_yaml_metadata(stream: Any) -> Any:
+    r"""Load YAML metadata with dates and timestamps as plain strings.
+
+    A drop-in replacement for ``yaml.safe_load`` for metadata documents:
+    unquoted YAML dates must reach the validator as strings rather than
+    ``datetime.date`` objects, which fail validation of string-typed schema
+    fields.
+
+    EXAMPLES::
+
+        >>> from mdstools.schema.validator import load_yaml_metadata
+        >>> load_yaml_metadata("date: 2021-07-09")
+        {'date': '2021-07-09'}
+
+        >>> import yaml
+        >>> yaml.safe_load("date: 2021-07-09")
+        {'date': datetime.date(2021, 7, 9)}
+
+    """
+    return _dates_to_strings(yaml.safe_load(stream))
+
+
 def _load_data(data: Any) -> dict:
     r"""Load metadata from a file path (YAML/JSON) or return a dict as-is.
+
+    YAML is loaded with :func:`load_yaml_metadata`, so unquoted dates stay
+    plain strings as required for validation of string-typed schema fields.
 
     EXAMPLES::
 
@@ -334,7 +390,7 @@ def _load_data(data: Any) -> dict:
             raise FileNotFoundError(f"File not found: {path}")
         with open(path, "r", encoding="utf-8") as f:
             if path.suffix in (".yaml", ".yml"):
-                return yaml.safe_load(f)
+                return load_yaml_metadata(f)
             if path.suffix == ".json":
                 return json.load(f)
             raise ValueError(f"Unsupported file extension: {path.suffix}")

--- a/mdstools/test/test_yaml_loading.py
+++ b/mdstools/test/test_yaml_loading.py
@@ -1,0 +1,83 @@
+"""Regression tests for YAML metadata loading (issue #123).
+
+Unquoted YAML dates (``date: 2021-07-09``) must load as plain strings so that
+string-typed schema fields validate; ``yaml.safe_load`` would turn them into
+``datetime.date`` objects and fail validation.
+"""
+
+# ********************************************************************
+#  This file is part of mdstools.
+#
+#        Copyright (C) 2026 Albert Engstfeld
+#
+#  mdstools is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  mdstools is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with mdstools. If not, see <https://www.gnu.org/licenses/>.
+# ********************************************************************
+
+import json
+import textwrap
+
+from mdstools.schema.validator import _load_data, validate_metadata
+
+UNQUOTED_DATE_YAML = textwrap.dedent("""
+    curation:
+      process:
+        - role: curator
+          name: Jane Doe
+          date: 2021-07-09
+    """)
+
+
+def test_unquoted_dates_load_as_strings(tmp_path):
+    """Unquoted YAML dates are loaded as plain strings, not datetime.date."""
+    metadata_file = tmp_path / "metadata.yaml"
+    metadata_file.write_text(UNQUOTED_DATE_YAML, encoding="utf-8")
+
+    data = _load_data(metadata_file)
+
+    assert data["curation"]["process"][0]["date"] == "2021-07-09"
+
+
+def test_unquoted_dates_validate_as_strings(tmp_path):
+    """A document with an unquoted date validates against a string-typed field."""
+    metadata_file = tmp_path / "metadata.yaml"
+    metadata_file.write_text(UNQUOTED_DATE_YAML, encoding="utf-8")
+
+    schema_file = tmp_path / "schema.json"
+    schema_file.write_text(
+        json.dumps(
+            {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "type": "object",
+                "properties": {
+                    "curation": {
+                        "type": "object",
+                        "properties": {
+                            "process": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "date": {"type": ["string", "null"]}
+                                    },
+                                },
+                            }
+                        },
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    validate_metadata(_load_data(metadata_file), str(schema_file))


### PR DESCRIPTION
yaml.safe_load resolves unquoted dates (date: 2021-07-09) to datetime.date objects, which fail validation of string-typed schema fields. Load metadata YAML through load_yaml_metadata, which converts dates and datetimes to ISO strings after loading.

Closes #123