### PR TITLE
Bump linkml to 1.11 to resolve click dependency conflict

### DIFF
--- a/doc/generate_schema_docs.py
+++ b/doc/generate_schema_docs.py
@@ -25,11 +25,26 @@ TEMPLATE_DIR = DOC_DIR / "_templates" / "docgen"
 def _postprocess_markdown(output_dir):
     """Fix generated markdown for Sphinx/MyST compatibility.
 
+    - Strip MkDocs-Material search front matter and search-exclude divs
+      (emitted by gen-doc >= 1.11; meaningless in Sphinx and the type pages
+      glue the closing --- onto the H1, which MyST rejects as a transition)
     - Convert ```mermaid to ```{mermaid} for sphinxcontrib-mermaid
     - Add a glob toctree to index.md so all generated pages are included
     """
     for md_file in output_dir.glob("*.md"):
         content = md_file.read_text(encoding="utf-8")
+        # Strip leading "search: boost" front matter; handles both the
+        # well-formed block and the malformed "---# Heading" variant
+        content = re.sub(
+            r"\A---\n.*?\n---", "", content, flags=re.DOTALL
+        ).lstrip("\n")
+        # Strip MkDocs search-exclude wrapper divs
+        content = re.sub(
+            r'^<div data-search-exclude markdown="1">\n|^</div>\n?',
+            "",
+            content,
+            flags=re.MULTILINE,
+        )
         # Convert fenced mermaid code blocks to MyST directive syntax
         content = re.sub(r"^```mermaid$", "```{mermaid}", content, flags=re.MULTILINE)
         # Remove mermaid blocks that contain only "None" (failed top-level diagrams)

--- a/doc/news/bump-linkml-1_11.rst
+++ b/doc/news/bump-linkml-1_11.rst
@@ -1,3 +1,7 @@
+**Added:**
+
+* Added ``pixi run test-generated-artifacts`` (part of ``pixi run test``), which regenerates the JSON Schemas and Pydantic models into a temporary directory and compares them with the committed files, catching stale generated artifacts locally instead of in CI.
+
 **Changed:**
 
 * Changed version bounds of `linkml` and `linkml-runtime` from `>=10,<11` to `>=11,<12`.

--- a/doc/news/bump-linkml-1_11.rst
+++ b/doc/news/bump-linkml-1_11.rst
@@ -1,3 +1,8 @@
 **Changed:**
 
 * Changed version bounds of `linkml` and `linkml-runtime` from `>=10,<11` to `>=11,<12`.
+* Regenerated JSON Schemas with LinkML 1.11: URL-typed properties now carry ``"format": "uri"`` and abstract base classes (e.g. ``ControlledOperation``) are included in ``$defs``.
+
+**Fixed:**
+
+* Strip MkDocs-Material search front matter and ``data-search-exclude`` divs from ``gen-doc`` output (new in LinkML 1.11), which broke the Sphinx/MyST documentation build.

--- a/doc/news/bump-linkml-1_11.rst
+++ b/doc/news/bump-linkml-1_11.rst
@@ -1,0 +1,3 @@
+**Changed:**
+
+* Changed version bounds of `linkml` and `linkml-runtime` from `>=10,<11` to `>=11,<12`.

--- a/mdstools/models/autotag.py
+++ b/mdstools/models/autotag.py
@@ -36,7 +36,7 @@ from pydantic import (
     model_serializer,
 )
 
-metamodel_version = "1.7.0"
+metamodel_version = "1.11.0"
 
 
 class ConfiguredBaseModel(BaseModel):

--- a/mdstools/models/echemdb_package.py
+++ b/mdstools/models/echemdb_package.py
@@ -36,7 +36,7 @@ from pydantic import (
     model_serializer,
 )
 
-metamodel_version = "1.7.0"
+metamodel_version = "1.11.0"
 
 
 class ConfiguredBaseModel(BaseModel):

--- a/mdstools/models/minimum_echemdb.py
+++ b/mdstools/models/minimum_echemdb.py
@@ -36,7 +36,7 @@ from pydantic import (
     model_serializer,
 )
 
-metamodel_version = "1.7.0"
+metamodel_version = "1.11.0"
 
 
 class ConfiguredBaseModel(BaseModel):

--- a/mdstools/models/source_data.py
+++ b/mdstools/models/source_data.py
@@ -36,7 +36,7 @@ from pydantic import (
     model_serializer,
 )
 
-metamodel_version = "1.7.0"
+metamodel_version = "1.11.0"
 
 
 class ConfiguredBaseModel(BaseModel):

--- a/mdstools/models/svgdigitizer.py
+++ b/mdstools/models/svgdigitizer.py
@@ -36,7 +36,7 @@ from pydantic import (
     model_serializer,
 )
 
-metamodel_version = "1.7.0"
+metamodel_version = "1.11.0"
 
 
 class ConfiguredBaseModel(BaseModel):

--- a/mdstools/models/svgdigitizer_package.py
+++ b/mdstools/models/svgdigitizer_package.py
@@ -36,7 +36,7 @@ from pydantic import (
     model_serializer,
 )
 
-metamodel_version = "1.7.0"
+metamodel_version = "1.11.0"
 
 
 class ConfiguredBaseModel(BaseModel):

--- a/mdstools/schema/generate_from_linkml.py
+++ b/mdstools/schema/generate_from_linkml.py
@@ -165,14 +165,15 @@ def _reorder_schema_keys(schema: dict) -> dict:
     return reordered
 
 
-def generate_json_schemas():
+def generate_json_schemas(output_dir: Path = SCHEMAS_DIR, ensure_frictionless=True):
     """Generate JSON Schema files from LinkML models."""
-    SCHEMAS_DIR.mkdir(parents=True, exist_ok=True)
-    ensure_frictionless_schemas(SCHEMAS_DIR)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    if ensure_frictionless:
+        ensure_frictionless_schemas(SCHEMAS_DIR)
 
     for model_name in MAIN_MODELS:
         linkml_file = LINKML_DIR / f"{model_name}.yaml"
-        output_file = SCHEMAS_DIR / f"{model_name}.json"
+        output_file = output_dir / f"{model_name}.json"
 
         if not linkml_file.exists():
             print(f"  SKIP {model_name} (LinkML file not found: {linkml_file})")
@@ -245,7 +246,7 @@ def generate_json_schemas():
 
         print(f"  OK {output_file.name}")
 
-    print(f"\nGenerated {len(MAIN_MODELS)} JSON Schema files in {SCHEMAS_DIR}")
+    print(f"\nGenerated {len(MAIN_MODELS)} JSON Schema files in {output_dir}")
 
 
 def _postprocess_pydantic(code: str) -> str:
@@ -291,12 +292,12 @@ def _postprocess_pydantic(code: str) -> str:
     return code
 
 
-def generate_pydantic_models():
+def generate_pydantic_models(output_dir: Path = MODELS_DIR):
     """Generate Pydantic models from LinkML models."""
-    MODELS_DIR.mkdir(parents=True, exist_ok=True)
+    output_dir.mkdir(parents=True, exist_ok=True)
 
     # Create __init__.py if it doesn't exist
-    init_file = MODELS_DIR / "__init__.py"
+    init_file = output_dir / "__init__.py"
     if not init_file.exists():
         init_file.write_text(
             '"""Auto-generated Pydantic models from LinkML schemas."""\n',
@@ -305,7 +306,7 @@ def generate_pydantic_models():
 
     for model_name in MAIN_MODELS:
         linkml_file = LINKML_DIR / f"{model_name}.yaml"
-        output_file = MODELS_DIR / f"{model_name}.py"
+        output_file = output_dir / f"{model_name}.py"
 
         if not linkml_file.exists():
             print(f"  SKIP {model_name} (LinkML file not found: {linkml_file})")
@@ -334,7 +335,7 @@ def generate_pydantic_models():
 
         print(f"  OK {output_file.name}")
 
-    print(f"\nGenerated {len(MAIN_MODELS)} Pydantic model files in {MODELS_DIR}")
+    print(f"\nGenerated {len(MAIN_MODELS)} Pydantic model files in {output_dir}")
 
 
 def main():

--- a/mdstools/test/test_generated_artifacts.py
+++ b/mdstools/test/test_generated_artifacts.py
@@ -1,0 +1,88 @@
+"""Verify that committed generated artifacts match a fresh regeneration.
+
+The JSON Schemas in ``schemas/`` and the Pydantic models in
+``mdstools/models/`` are generated from the LinkML sources in ``linkml/``.
+These tests regenerate both into a temporary directory and compare them with
+the committed files, so that stale artifacts are caught locally instead of by
+the ``git diff --exit-code -- schemas mdstools/models`` check in CI.
+
+If a test fails, run ``pixi run generate-all`` and commit the result.
+"""
+
+# ********************************************************************
+#  This file is part of mdstools.
+#
+#        Copyright (C) 2026 Albert Engstfeld
+#
+#  mdstools is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  mdstools is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with mdstools. If not, see <https://www.gnu.org/licenses/>.
+# ********************************************************************
+
+import difflib
+
+import pytest
+
+from mdstools.schema.generate_from_linkml import (
+    MAIN_MODELS,
+    MODELS_DIR,
+    SCHEMAS_DIR,
+    generate_json_schemas,
+    generate_pydantic_models,
+)
+
+REGENERATE_HINT = "Run `pixi run generate-all` and commit the changes."
+
+
+def _diff(expected: str, actual: str, name: str) -> str:
+    return "".join(
+        difflib.unified_diff(
+            expected.splitlines(keepends=True),
+            actual.splitlines(keepends=True),
+            fromfile=f"committed/{name}",
+            tofile=f"regenerated/{name}",
+        )
+    )
+
+
+def test_json_schemas_up_to_date(tmp_path):
+    """Committed JSON Schemas match a fresh regeneration from LinkML."""
+    generate_json_schemas(output_dir=tmp_path, ensure_frictionless=False)
+
+    for model_name in MAIN_MODELS:
+        name = f"{model_name}.json"
+        committed = (SCHEMAS_DIR / name).read_text(encoding="utf-8")
+        regenerated = (tmp_path / name).read_text(encoding="utf-8")
+        message = f"schemas/{name} is stale. {REGENERATE_HINT}\n" + _diff(
+            committed, regenerated, name
+        )
+        assert committed == regenerated, message
+
+
+def test_pydantic_models_up_to_date(tmp_path):
+    """Committed Pydantic models match a fresh regeneration from LinkML."""
+    # Committed models are black-formatted (see the generate-models pixi
+    # task), so the raw gen-pydantic output must be formatted before
+    # comparison. black is only available in the dev environment.
+    black = pytest.importorskip("black")
+
+    generate_pydantic_models(output_dir=tmp_path)
+
+    for model_name in MAIN_MODELS:
+        name = f"{model_name}.py"
+        committed = (MODELS_DIR / name).read_text(encoding="utf-8")
+        regenerated = (tmp_path / name).read_text(encoding="utf-8")
+        regenerated = black.format_str(regenerated, mode=black.Mode())
+        message = f"mdstools/models/{name} is stale. {REGENERATE_HINT}\n" + _diff(
+            committed, regenerated, name
+        )
+        assert committed == regenerated, message

--- a/pixi.lock
+++ b/pixi.lock
@@ -172,7 +172,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/chardet-7.4.3-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/check-jsonschema-0.36.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.8-pyh707e725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.2-pyhc90fa1f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.14.6-py314hd8ed1ab_100.conda
@@ -230,8 +230,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.28.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupytext-1.19.4-pyh0398c0e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/lark-1.3.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-1.10.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-runtime-1.9.5-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-1.11.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-runtime-1.11.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.6.1-pyhd8ed1ab_0.conda
@@ -348,7 +348,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/chardet-7.4.3-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/check-jsonschema-0.36.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.8-pyh707e725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.2-pyhc90fa1f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.14.6-py314hd8ed1ab_100.conda
@@ -406,8 +406,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.28.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupytext-1.19.4-pyh0398c0e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/lark-1.3.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-1.10.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-runtime-1.9.5-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-1.11.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-runtime-1.11.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.6.1-pyhd8ed1ab_0.conda
@@ -609,7 +609,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/chardet-7.4.3-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/check-jsonschema-0.36.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.8-pyh7428d3b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.2-pyh6dadd2b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.14.6-py314hd8ed1ab_100.conda
@@ -667,8 +667,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.28.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupytext-1.19.4-pyh0398c0e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/lark-1.3.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-1.10.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-runtime-1.9.5-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-1.11.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-runtime-1.11.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/m2-bash-5.2.037.2-hc364b38_6.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/m2-filesystem-2025.02.23.1-hc364b38_10.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/m2-msys2-runtime-3.6.1.4-hc364b38_6.conda
@@ -1020,7 +1020,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/chardet-7.4.3-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/check-jsonschema-0.36.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.8-pyh707e725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.2-pyhc90fa1f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.14.6-py314hd8ed1ab_100.conda
@@ -1082,8 +1082,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.28.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupytext-1.19.4-pyh0398c0e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/lark-1.3.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-1.10.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-runtime-1.9.5-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-1.11.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-runtime-1.11.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mccabe-0.7.0-pyhd8ed1ab_1.conda
@@ -1218,7 +1218,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/chardet-7.4.3-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/check-jsonschema-0.36.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.8-pyh707e725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.2-pyhc90fa1f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.14.6-py314hd8ed1ab_100.conda
@@ -1280,8 +1280,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.28.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupytext-1.19.4-pyh0398c0e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/lark-1.3.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-1.10.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-runtime-1.9.5-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-1.11.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-runtime-1.11.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mccabe-0.7.0-pyhd8ed1ab_1.conda
@@ -1503,7 +1503,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/chardet-7.4.3-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/check-jsonschema-0.36.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.8-pyh7428d3b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.2-pyh6dadd2b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.14.6-py314hd8ed1ab_100.conda
@@ -1565,8 +1565,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.28.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupytext-1.19.4-pyh0398c0e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/lark-1.3.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-1.10.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-runtime-1.9.5-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-1.11.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-runtime-1.11.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/m2-bash-5.2.037.2-hc364b38_6.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/m2-filesystem-2025.02.23.1-hc364b38_10.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/m2-msys2-runtime-3.6.1.4-hc364b38_6.conda
@@ -1934,7 +1934,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/chardet-7.4.3-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/check-jsonschema-0.36.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.8-pyh707e725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.2-pyhc90fa1f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/curies-0.7.4-pyhd8ed1ab_0.conda
@@ -1993,8 +1993,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.28.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupytext-1.19.4-pyh0398c0e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/lark-1.3.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-1.10.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-runtime-1.9.5-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-1.11.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-runtime-1.11.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.6.1-pyhd8ed1ab_0.conda
@@ -2115,7 +2115,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/chardet-7.4.3-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/check-jsonschema-0.36.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.8-pyh707e725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.2-pyhc90fa1f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/curies-0.7.4-pyhd8ed1ab_0.conda
@@ -2174,8 +2174,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.28.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupytext-1.19.4-pyh0398c0e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/lark-1.3.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-1.10.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-runtime-1.9.5-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-1.11.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-runtime-1.11.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.6.1-pyhd8ed1ab_0.conda
@@ -2380,7 +2380,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/chardet-7.4.3-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/check-jsonschema-0.36.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.8-pyh7428d3b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.2-pyh6dadd2b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/curies-0.7.4-pyhd8ed1ab_0.conda
@@ -2439,8 +2439,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.28.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupytext-1.19.4-pyh0398c0e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/lark-1.3.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-1.10.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-runtime-1.9.5-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-1.11.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-runtime-1.11.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/m2-bash-5.2.037.2-hc364b38_6.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/m2-filesystem-2025.02.23.1-hc364b38_10.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/m2-msys2-runtime-3.6.1.4-hc364b38_6.conda
@@ -2795,7 +2795,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/chardet-7.4.3-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/check-jsonschema-0.36.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.8-pyh707e725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.2-pyhc90fa1f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.12.13-py312hd8ed1ab_0.conda
@@ -2855,8 +2855,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.28.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupytext-1.19.4-pyh0398c0e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/lark-1.3.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-1.10.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-runtime-1.9.5-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-1.11.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-runtime-1.11.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.6.1-pyhd8ed1ab_0.conda
@@ -2979,7 +2979,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/chardet-7.4.3-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/check-jsonschema-0.36.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.8-pyh707e725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.2-pyhc90fa1f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.12.13-py312hd8ed1ab_0.conda
@@ -3039,8 +3039,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.28.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupytext-1.19.4-pyh0398c0e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/lark-1.3.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-1.10.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-runtime-1.9.5-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-1.11.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-runtime-1.11.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.6.1-pyhd8ed1ab_0.conda
@@ -3247,7 +3247,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/chardet-7.4.3-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/check-jsonschema-0.36.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.8-pyh7428d3b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.2-pyh6dadd2b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.12.13-py312hd8ed1ab_0.conda
@@ -3307,8 +3307,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.28.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupytext-1.19.4-pyh0398c0e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/lark-1.3.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-1.10.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-runtime-1.9.5-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-1.11.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-runtime-1.11.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/m2-bash-5.2.037.2-hc364b38_6.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/m2-filesystem-2025.02.23.1-hc364b38_10.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/m2-msys2-runtime-3.6.1.4-hc364b38_6.conda
@@ -3663,7 +3663,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/chardet-7.4.3-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/check-jsonschema-0.36.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.8-pyh707e725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.2-pyhc90fa1f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.13.14-py313hd8ed1ab_100.conda
@@ -3723,8 +3723,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.28.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupytext-1.19.4-pyh0398c0e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/lark-1.3.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-1.10.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-runtime-1.9.5-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-1.11.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-runtime-1.11.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.6.1-pyhd8ed1ab_0.conda
@@ -3846,7 +3846,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/chardet-7.4.3-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/check-jsonschema-0.36.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.8-pyh707e725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.2-pyhc90fa1f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.13.14-py313hd8ed1ab_100.conda
@@ -3906,8 +3906,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.28.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupytext-1.19.4-pyh0398c0e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/lark-1.3.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-1.10.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-runtime-1.9.5-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-1.11.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-runtime-1.11.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.6.1-pyhd8ed1ab_0.conda
@@ -4114,7 +4114,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/chardet-7.4.3-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/check-jsonschema-0.36.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.8-pyh7428d3b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.2-pyh6dadd2b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.13.14-py313hd8ed1ab_100.conda
@@ -4174,8 +4174,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.28.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupytext-1.19.4-pyh0398c0e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/lark-1.3.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-1.10.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-runtime-1.9.5-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-1.11.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-runtime-1.11.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/m2-bash-5.2.037.2-hc364b38_6.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/m2-filesystem-2025.02.23.1-hc364b38_10.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/m2-msys2-runtime-3.6.1.4-hc364b38_6.conda
@@ -4530,7 +4530,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/chardet-7.4.3-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/check-jsonschema-0.36.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.8-pyh707e725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.2-pyhc90fa1f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.14.6-py314hd8ed1ab_100.conda
@@ -4590,8 +4590,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.28.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupytext-1.19.4-pyh0398c0e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/lark-1.3.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-1.10.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-runtime-1.9.5-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-1.11.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-runtime-1.11.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.6.1-pyhd8ed1ab_0.conda
@@ -4714,7 +4714,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/chardet-7.4.3-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/check-jsonschema-0.36.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.8-pyh707e725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.2-pyhc90fa1f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.14.6-py314hd8ed1ab_100.conda
@@ -4774,8 +4774,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.28.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupytext-1.19.4-pyh0398c0e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/lark-1.3.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-1.10.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-runtime-1.9.5-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-1.11.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-runtime-1.11.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.6.1-pyhd8ed1ab_0.conda
@@ -4982,7 +4982,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/chardet-7.4.3-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/check-jsonschema-0.36.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.8-pyh7428d3b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.2-pyh6dadd2b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.14.6-py314hd8ed1ab_100.conda
@@ -5042,8 +5042,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.28.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupytext-1.19.4-pyh0398c0e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/lark-1.3.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-1.10.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-runtime-1.9.5-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-1.11.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-runtime-1.11.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/m2-bash-5.2.037.2-hc364b38_6.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/m2-filesystem-2025.02.23.1-hc364b38_10.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/m2-msys2-runtime-3.6.1.4-hc364b38_6.conda
@@ -5404,7 +5404,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/chardet-7.4.3-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/check-jsonschema-0.36.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.8-pyh707e725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.2-pyhc90fa1f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.14.6-py314hd8ed1ab_100.conda
@@ -5464,8 +5464,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupytext-1.19.4-pyh0398c0e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/lark-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/lazyasd-0.1.4-py_1.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-1.10.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-runtime-1.9.5-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-1.11.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-runtime-1.11.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.6.1-pyhd8ed1ab_0.conda
@@ -5588,7 +5588,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/chardet-7.4.3-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/check-jsonschema-0.36.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.8-pyh707e725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.2-pyhc90fa1f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.14.6-py314hd8ed1ab_100.conda
@@ -5648,8 +5648,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupytext-1.19.4-pyh0398c0e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/lark-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/lazyasd-0.1.4-py_1.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-1.10.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-runtime-1.9.5-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-1.11.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-runtime-1.11.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.6.1-pyhd8ed1ab_0.conda
@@ -5859,7 +5859,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/chardet-7.4.3-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/check-jsonschema-0.36.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.8-pyh7428d3b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.2-pyh6dadd2b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.14.6-py314hd8ed1ab_100.conda
@@ -5919,8 +5919,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupytext-1.19.4-pyh0398c0e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/lark-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/lazyasd-0.1.4-py_1.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-1.10.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-runtime-1.9.5-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-1.11.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkml-runtime-1.11.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/m2-bash-5.2.037.2-hc364b38_6.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/m2-filesystem-2025.02.23.1-hc364b38_10.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/m2-msys2-runtime-3.6.1.4-hc364b38_6.conda
@@ -7884,7 +7884,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/numpy?source=compressed-mapping
+  - pkg:pypi/numpy?source=hash-mapping
   run_exports:
     weak:
     - numpy >=1.23,<3
@@ -7930,7 +7930,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/numpy?source=compressed-mapping
+  - pkg:pypi/numpy?source=hash-mapping
   run_exports:
     weak:
     - numpy >=1.25,<3
@@ -8807,7 +8807,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/rpds-py?source=compressed-mapping
+  - pkg:pypi/rpds-py?source=hash-mapping
   run_exports: {}
   size: 299898
   timestamp: 1782831307838
@@ -8824,7 +8824,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/rpds-py?source=compressed-mapping
+  - pkg:pypi/rpds-py?source=hash-mapping
   run_exports: {}
   size: 300259
   timestamp: 1782831325201
@@ -9127,7 +9127,7 @@ packages:
   license: Apache-2.0
   license_family: Apache
   purls:
-  - pkg:pypi/tornado?source=compressed-mapping
+  - pkg:pypi/tornado?source=hash-mapping
   run_exports: {}
   size: 885824
   timestamp: 1781006802459
@@ -9260,7 +9260,7 @@ packages:
   license: BSD-2-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/wrapt?source=compressed-mapping
+  - pkg:pypi/wrapt?source=hash-mapping
   run_exports: {}
   size: 117401
   timestamp: 1782133645625
@@ -9275,7 +9275,7 @@ packages:
   license: BSD-2-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/wrapt?source=compressed-mapping
+  - pkg:pypi/wrapt?source=hash-mapping
   run_exports: {}
   size: 118096
   timestamp: 1782133651496
@@ -9879,8 +9879,7 @@ packages:
   depends:
   - python >=3.14
   license: BSD-3-Clause AND MIT AND EPL-2.0
-  purls:
-  - pkg:pypi/backports-zstd?source=compressed-mapping
+  purls: []
   run_exports: {}
   size: 7526
   timestamp: 1781450817767
@@ -9927,7 +9926,7 @@ packages:
   - tinycss2 >=1.1.0,<1.5
   license: Apache-2.0 AND MIT
   purls:
-  - pkg:pypi/bleach?source=compressed-mapping
+  - pkg:pypi/bleach?source=hash-mapping
   run_exports: {}
   size: 142246
   timestamp: 1780675823953
@@ -10052,33 +10051,35 @@ packages:
   run_exports: {}
   size: 234466
   timestamp: 1771354776999
-- conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.8-pyh707e725_0.conda
-  sha256: c920d23cd1fcf565031c679adb62d848af60d6fbb0edc2d50ba475cea4f0d8ab
-  md5: f22f4d4970e09d68a10b922cbb0408d3
-  depends:
-  - __unix
-  - python >=3.9
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/click?source=hash-mapping
-  run_exports: {}
-  size: 84705
-  timestamp: 1734858922844
-- conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.8-pyh7428d3b_0.conda
-  sha256: c889ed359ae47eead4ffe8927b7206b22c55e67d6e74a9044c23736919d61e8d
-  md5: 90e5571556f7a45db92ee51cb8f97af6
+- conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.2-pyh6dadd2b_0.conda
+  sha256: 5b5c96afdd801dd9c3b78ebc2cd9a9f3ce34186257415d394dde1aa8468aa3c0
+  md5: 8a0d65027e25e367f9f1754f0604e8de
   depends:
   - __win
   - colorama
-  - python >=3.9
+  - python >=3.10
+  - python
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/click?source=hash-mapping
+  - pkg:pypi/click?source=compressed-mapping
   run_exports: {}
-  size: 85169
-  timestamp: 1734858972635
+  size: 106227
+  timestamp: 1783085395110
+- conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.2-pyhc90fa1f_0.conda
+  sha256: ccc4787f511964f9a1f2d2d2859c91c5d571fb60f7f09d4c4e092c9b7a94e671
+  md5: 2c4bd6aeb90bb157456841c3270a0d92
+  depends:
+  - __unix
+  - python
+  - python >=3.10
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/click?source=compressed-mapping
+  run_exports: {}
+  size: 107155
+  timestamp: 1783085363526
 - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
   sha256: ab29d57dc70786c1269633ba3dff20288b81664d3ff8d21af995742e2bb03287
   md5: 962b9857ee8e7018c22f2776ffa0b2d7
@@ -11129,18 +11130,18 @@ packages:
   run_exports: {}
   size: 11888
   timestamp: 1530842683457
-- conda: https://conda.anaconda.org/conda-forge/noarch/linkml-1.10.0-pyhcf101f3_0.conda
-  sha256: 3a9486cd18b5fac677243d3d0d792d390a6d4e606b1c94a938a1c2736bfa182f
-  md5: a182720d4755201f3f55fb8dfc80b7c9
+- conda: https://conda.anaconda.org/conda-forge/noarch/linkml-1.11.1-pyhcf101f3_0.conda
+  sha256: ae2fad4f1b1f05ad053cea86b97f74f96732b728baf3eb892d9d84612740aba7
+  md5: 4dfc3599ae673e3ce41c87114779cc84
   depends:
   - antlr4-python3-runtime >=4.9.0,<4.10
-  - click >=8.0,<8.2
+  - click >=8.2
   - hbreader
   - isodate >=0.6.0
   - jinja2 >=3.1.0
   - jsonasobj2 >=1.0.3,<2.0.0
   - jsonschema-with-format >=4.0.0
-  - linkml-runtime >=1.9.5,<2.0.0
+  - linkml-runtime >=1.10.0,<2.0.0
   - openpyxl
   - parse
   - prefixcommons >=0.1.7
@@ -11170,24 +11171,24 @@ packages:
   purls:
   - pkg:pypi/linkml?source=hash-mapping
   run_exports: {}
-  size: 322390
-  timestamp: 1773069543447
-- conda: https://conda.anaconda.org/conda-forge/noarch/linkml-runtime-1.9.5-pyhe01879c_0.conda
-  sha256: 404ad96ee2cbdc4bc6a2a53788511354856688bccb4519a501da1fcdff55ded4
-  md5: 5df32583db662f421f15b80426a55f66
+  size: 356798
+  timestamp: 1779301803770
+- conda: https://conda.anaconda.org/conda-forge/noarch/linkml-runtime-1.11.1-pyhcf101f3_0.conda
+  sha256: 76248d885ed8a203be651bf02f73807ac5a7add3b418bf2b70ac4d0772a49dd5
+  md5: be55844649ea0a3bb021b42d2f7b7f83
   depends:
-  - click
+  - click >=8.2
   - curies >=0.5.4
   - deprecated
   - hbreader
   - isodate >=0.7.2,<1.0.0
   - json-flattener >=0.1.9
-  - jsonasobj2 >=1.0.0,>=1.0.4
+  - jsonasobj2 >=1.0.4,<2
   - jsonschema >=3.2.0
   - prefixcommons >=0.1.12
   - prefixmaps >=0.1.4
   - pydantic >=1.10.2,<3.0.0
-  - python >=3.9
+  - python >=3.10
   - pyyaml
   - rdflib >=6.0.0
   - requests
@@ -11196,8 +11197,8 @@ packages:
   purls:
   - pkg:pypi/linkml-runtime?source=hash-mapping
   run_exports: {}
-  size: 317980
-  timestamp: 1755309827185
+  size: 350753
+  timestamp: 1779301803770
 - conda: https://conda.anaconda.org/conda-forge/noarch/m2-bash-5.2.037.2-hc364b38_6.conda
   sha256: b2b243cd336e58d0c241bb9eb799e30713b8a40806b14d242fadd96804ff8cd6
   md5: 804c029d36d971e8de1e56016f8054a5
@@ -11256,7 +11257,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/matplotlib-inline?source=compressed-mapping
+  - pkg:pypi/matplotlib-inline?source=hash-mapping
   run_exports: {}
   size: 15725
   timestamp: 1778264403247
@@ -12040,7 +12041,7 @@ packages:
   license: BSD-2-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/python-json-logger?source=compressed-mapping
+  - pkg:pypi/python-json-logger?source=hash-mapping
   run_exports: {}
   size: 19249
   timestamp: 1781036004580
@@ -13530,7 +13531,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/greenlet?source=compressed-mapping
+  - pkg:pypi/greenlet?source=hash-mapping
   run_exports: {}
   size: 260470
   timestamp: 1782524836843
@@ -13545,7 +13546,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/greenlet?source=compressed-mapping
+  - pkg:pypi/greenlet?source=hash-mapping
   run_exports: {}
   size: 261350
   timestamp: 1782524782743
@@ -14355,7 +14356,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/numpy?source=compressed-mapping
+  - pkg:pypi/numpy?source=hash-mapping
   run_exports:
     weak:
     - numpy >=1.25,<3
@@ -15225,7 +15226,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/pyzmq?source=compressed-mapping
+  - pkg:pypi/pyzmq?source=hash-mapping
   run_exports: {}
   size: 192531
   timestamp: 1779484028794
@@ -15335,7 +15336,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/rpds-py?source=compressed-mapping
+  - pkg:pypi/rpds-py?source=hash-mapping
   run_exports: {}
   size: 301356
   timestamp: 1782831427136
@@ -15351,7 +15352,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/rpds-py?source=compressed-mapping
+  - pkg:pypi/rpds-py?source=hash-mapping
   run_exports: {}
   size: 300879
   timestamp: 1782831643076
@@ -15719,7 +15720,7 @@ packages:
   license: BSD-2-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/wrapt?source=compressed-mapping
+  - pkg:pypi/wrapt?source=hash-mapping
   run_exports: {}
   size: 112223
   timestamp: 1782134110163
@@ -15733,7 +15734,7 @@ packages:
   license: BSD-2-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/wrapt?source=compressed-mapping
+  - pkg:pypi/wrapt?source=hash-mapping
   run_exports: {}
   size: 113519
   timestamp: 1782134186680
@@ -16388,7 +16389,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/greenlet?source=compressed-mapping
+  - pkg:pypi/greenlet?source=hash-mapping
   run_exports: {}
   size: 249080
   timestamp: 1782524683597
@@ -17991,7 +17992,7 @@ packages:
   license: PSF-2.0
   license_family: PSF
   purls:
-  - pkg:pypi/pywin32?source=compressed-mapping
+  - pkg:pypi/pywin32?source=hash-mapping
   run_exports: {}
   size: 4459779
   timestamp: 1781362887119
@@ -18007,7 +18008,7 @@ packages:
   license: PSF-2.0
   license_family: PSF
   purls:
-  - pkg:pypi/pywin32?source=compressed-mapping
+  - pkg:pypi/pywin32?source=hash-mapping
   run_exports: {}
   size: 4466467
   timestamp: 1781362878201
@@ -18023,7 +18024,7 @@ packages:
   license: PSF-2.0
   license_family: PSF
   purls:
-  - pkg:pypi/pywin32?source=compressed-mapping
+  - pkg:pypi/pywin32?source=hash-mapping
   run_exports: {}
   size: 4472831
   timestamp: 1781362876741
@@ -18291,7 +18292,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/rpds-py?source=compressed-mapping
+  - pkg:pypi/rpds-py?source=hash-mapping
   run_exports: {}
   size: 217956
   timestamp: 1782831653430
@@ -18307,7 +18308,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/rpds-py?source=compressed-mapping
+  - pkg:pypi/rpds-py?source=hash-mapping
   run_exports: {}
   size: 217714
   timestamp: 1782831718457
@@ -18769,7 +18770,7 @@ packages:
   license: BSD-2-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/wrapt?source=compressed-mapping
+  - pkg:pypi/wrapt?source=hash-mapping
   run_exports: {}
   size: 115115
   timestamp: 1782133736690
@@ -18785,7 +18786,7 @@ packages:
   license: BSD-2-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/wrapt?source=compressed-mapping
+  - pkg:pypi/wrapt?source=hash-mapping
   run_exports: {}
   size: 113162
   timestamp: 1782133745435
@@ -18801,7 +18802,7 @@ packages:
   license: BSD-2-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/wrapt?source=compressed-mapping
+  - pkg:pypi/wrapt?source=hash-mapping
   run_exports: {}
   size: 114396
   timestamp: 1782133745518
@@ -18817,7 +18818,7 @@ packages:
   license: BSD-2-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/wrapt?source=compressed-mapping
+  - pkg:pypi/wrapt?source=hash-mapping
   run_exports: {}
   size: 115544
   timestamp: 1782133735742
@@ -19046,8 +19047,8 @@ packages:
   - jsonref>=1.1,<2
   - referencing>=0.35,<1
   - ruamel-yaml>=0.18,<0.19
-  - linkml>=1.10,<1.11
-  - linkml-runtime>=1.9,<1.10
+  - linkml>=1.11,<1.12
+  - linkml-runtime>=1.10,<1.12
   requires_python: '>=3.11'
 - pypi: https://files.pythonhosted.org/packages/3a/0c/3662f4a66880196a590b202f0db82d919dd2f89e99a27fadef91c4a33d41/xlsxwriter-3.2.9-py3-none-any.whl
   name: xlsxwriter

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,10 +90,11 @@ pytest-doctestplus = ">=1.7.1,<2"
 pytest-remotedata = ">=0.4.1,<0.5"
 
 [tool.pixi.feature.test.tasks]
-doctest = "pytest -n auto --doctest-plus mdstools --ignore=mdstools/test/test_comprehensive.py --ignore=mdstools/test/test_resolved_schemas.py"
+doctest = "pytest -n auto --doctest-plus mdstools --ignore=mdstools/test/test_comprehensive.py --ignore=mdstools/test/test_resolved_schemas.py --ignore=mdstools/test/test_generated_artifacts.py"
 test-comprehensive = "pytest mdstools/test/test_comprehensive.py -v"
 test-resolved-schemas = "pytest mdstools/test/test_resolved_schemas.py -v"
-test-all = { depends-on = ["doctest", "test-comprehensive", "test-resolved-schemas"] }
+test-generated-artifacts = "pytest mdstools/test/test_generated_artifacts.py -v"
+test-all = { depends-on = ["doctest", "test-comprehensive", "test-resolved-schemas", "test-generated-artifacts"] }
 
 [tool.pixi.feature.lint.dependencies]
 black = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,8 +18,8 @@ dependencies = [
     "jsonref>=1.1,<2",
     "referencing>=0.35,<1",
     "ruamel.yaml>=0.18,<0.19",
-    "linkml>=1.10,<1.11",
-    "linkml-runtime>=1.9,<1.10",
+    "linkml>=1.11,<1.12",
+    "linkml-runtime>=1.10,<1.12",
 ]
 
 [project.scripts]
@@ -60,8 +60,8 @@ check-jsonschema = ">=0.36.1,<0.37"
 pyyaml = ">=6.0.3,<7"
 jsonschema = ">=4.23.0,<5"
 click = ">=8,<9"
-linkml = ">=1.10,<1.11"
-linkml-runtime = ">=1.9,<1.10"
+linkml = ">=1.11,<1.12"
+linkml-runtime = ">=1.10,<1.12"
 jsonref = ">=1.1.0,<2"
 "ruamel.yaml" = ">=0.18,<0.19"
 

--- a/schemas/autotag.json
+++ b/schemas/autotag.json
@@ -107,6 +107,7 @@
         },
         "url": {
           "description": "URL with further details on the atmospheric setup or control system.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": [
             "string",
@@ -416,6 +417,25 @@
       "title": "Control",
       "type": "object"
     },
+    "ControlledOperation": {
+      "additionalProperties": false,
+      "description": "Base class for a controlled operation characterised by one or more quantities, sharing a single control block.",
+      "properties": {
+        "control": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Control"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "How the operation was controlled."
+        }
+      },
+      "title": "ControlledOperation",
+      "type": "object"
+    },
     "ControlledQuantity": {
       "additionalProperties": false,
       "description": "A physical quantity that was actively controlled by an instrument.",
@@ -656,6 +676,7 @@
       "properties": {
         "url": {
           "description": "URL to product page or technical documentation.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": [
             "string",
@@ -802,6 +823,7 @@
         },
         "url": {
           "description": "URL to detailed preparation protocol or procedure, such as an article DOI.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": [
             "string",
@@ -857,6 +879,7 @@
         },
         "url": {
           "description": "URL to product specification or datasheet.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": [
             "string",
@@ -992,6 +1015,7 @@
       "properties": {
         "url": {
           "description": "URL to the electronic lab notebook entry.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": "string"
         }
@@ -1046,6 +1070,7 @@
         },
         "url": {
           "description": "URL to related documentation, publication (DOI), or ELN entry.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": [
             "string",
@@ -1309,6 +1334,7 @@
         },
         "orcid": {
           "description": "An URL containing the ORCID.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": "string"
         },
@@ -1356,6 +1382,7 @@
         },
         "url": {
           "description": "URL to project website or information page.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": [
             "string",
@@ -1432,6 +1459,7 @@
         },
         "url": {
           "description": "URL with further details on the purity or container.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": [
             "string",

--- a/schemas/echemdb_package.json
+++ b/schemas/echemdb_package.json
@@ -73,6 +73,7 @@
         },
         "url": {
           "description": "URL with further details on the atmospheric setup or control system.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": [
             "string",
@@ -321,6 +322,25 @@
         }
       },
       "title": "Control",
+      "type": "object"
+    },
+    "ControlledOperation": {
+      "additionalProperties": false,
+      "description": "Base class for a controlled operation characterised by one or more quantities, sharing a single control block.",
+      "properties": {
+        "control": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Control"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "How the operation was controlled."
+        }
+      },
+      "title": "ControlledOperation",
       "type": "object"
     },
     "ControlledQuantity": {
@@ -664,6 +684,7 @@
       "properties": {
         "url": {
           "description": "URL to product page or technical documentation.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": [
             "string",
@@ -810,6 +831,7 @@
         },
         "url": {
           "description": "URL to detailed preparation protocol or procedure, such as an article DOI.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": [
             "string",
@@ -865,6 +887,7 @@
         },
         "url": {
           "description": "URL to product specification or datasheet.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": [
             "string",
@@ -1038,6 +1061,7 @@
         },
         "url": {
           "description": "URL to related documentation, publication (DOI), or ELN entry.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": [
             "string",
@@ -1301,6 +1325,7 @@
         },
         "orcid": {
           "description": "An URL containing the ORCID.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": "string"
         },
@@ -1380,6 +1405,7 @@
         },
         "url": {
           "description": "URL with further details on the purity or container.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": [
             "string",
@@ -1586,6 +1612,7 @@
         },
         "url": {
           "description": "DOI (URL) to the publication or dataset.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": "string"
         }

--- a/schemas/expected/autotag.json
+++ b/schemas/expected/autotag.json
@@ -107,6 +107,7 @@
         },
         "url": {
           "description": "URL with further details on the atmospheric setup or control system.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": [
             "string",
@@ -416,6 +417,25 @@
       "title": "Control",
       "type": "object"
     },
+    "ControlledOperation": {
+      "additionalProperties": false,
+      "description": "Base class for a controlled operation characterised by one or more quantities, sharing a single control block.",
+      "properties": {
+        "control": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Control"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "How the operation was controlled."
+        }
+      },
+      "title": "ControlledOperation",
+      "type": "object"
+    },
     "ControlledQuantity": {
       "additionalProperties": false,
       "description": "A physical quantity that was actively controlled by an instrument.",
@@ -656,6 +676,7 @@
       "properties": {
         "url": {
           "description": "URL to product page or technical documentation.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": [
             "string",
@@ -802,6 +823,7 @@
         },
         "url": {
           "description": "URL to detailed preparation protocol or procedure, such as an article DOI.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": [
             "string",
@@ -857,6 +879,7 @@
         },
         "url": {
           "description": "URL to product specification or datasheet.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": [
             "string",
@@ -992,6 +1015,7 @@
       "properties": {
         "url": {
           "description": "URL to the electronic lab notebook entry.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": "string"
         }
@@ -1046,6 +1070,7 @@
         },
         "url": {
           "description": "URL to related documentation, publication (DOI), or ELN entry.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": [
             "string",
@@ -1309,6 +1334,7 @@
         },
         "orcid": {
           "description": "An URL containing the ORCID.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": "string"
         },
@@ -1356,6 +1382,7 @@
         },
         "url": {
           "description": "URL to project website or information page.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": [
             "string",
@@ -1432,6 +1459,7 @@
         },
         "url": {
           "description": "URL with further details on the purity or container.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": [
             "string",

--- a/schemas/expected/echemdb_package.json
+++ b/schemas/expected/echemdb_package.json
@@ -73,6 +73,7 @@
         },
         "url": {
           "description": "URL with further details on the atmospheric setup or control system.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": [
             "string",
@@ -321,6 +322,25 @@
         }
       },
       "title": "Control",
+      "type": "object"
+    },
+    "ControlledOperation": {
+      "additionalProperties": false,
+      "description": "Base class for a controlled operation characterised by one or more quantities, sharing a single control block.",
+      "properties": {
+        "control": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Control"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "How the operation was controlled."
+        }
+      },
+      "title": "ControlledOperation",
       "type": "object"
     },
     "ControlledQuantity": {
@@ -664,6 +684,7 @@
       "properties": {
         "url": {
           "description": "URL to product page or technical documentation.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": [
             "string",
@@ -810,6 +831,7 @@
         },
         "url": {
           "description": "URL to detailed preparation protocol or procedure, such as an article DOI.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": [
             "string",
@@ -865,6 +887,7 @@
         },
         "url": {
           "description": "URL to product specification or datasheet.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": [
             "string",
@@ -1038,6 +1061,7 @@
         },
         "url": {
           "description": "URL to related documentation, publication (DOI), or ELN entry.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": [
             "string",
@@ -1301,6 +1325,7 @@
         },
         "orcid": {
           "description": "An URL containing the ORCID.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": "string"
         },
@@ -1380,6 +1405,7 @@
         },
         "url": {
           "description": "URL with further details on the purity or container.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": [
             "string",
@@ -1586,6 +1612,7 @@
         },
         "url": {
           "description": "DOI (URL) to the publication or dataset.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": "string"
         }

--- a/schemas/expected/minimum_echemdb.json
+++ b/schemas/expected/minimum_echemdb.json
@@ -90,6 +90,7 @@
         },
         "url": {
           "description": "URL with further details on the atmospheric setup or control system.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": [
             "string",
@@ -340,6 +341,25 @@
       "title": "Control",
       "type": "object"
     },
+    "ControlledOperation": {
+      "additionalProperties": false,
+      "description": "Base class for a controlled operation characterised by one or more quantities, sharing a single control block.",
+      "properties": {
+        "control": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Control"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "How the operation was controlled."
+        }
+      },
+      "title": "ControlledOperation",
+      "type": "object"
+    },
     "ControlledQuantity": {
       "additionalProperties": false,
       "description": "A physical quantity that was actively controlled by an instrument.",
@@ -580,6 +600,7 @@
       "properties": {
         "url": {
           "description": "URL to product page or technical documentation.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": [
             "string",
@@ -726,6 +747,7 @@
         },
         "url": {
           "description": "URL to detailed preparation protocol or procedure, such as an article DOI.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": [
             "string",
@@ -781,6 +803,7 @@
         },
         "url": {
           "description": "URL to product specification or datasheet.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": [
             "string",
@@ -954,6 +977,7 @@
         },
         "url": {
           "description": "URL to related documentation, publication (DOI), or ELN entry.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": [
             "string",
@@ -1259,6 +1283,7 @@
         },
         "orcid": {
           "description": "An URL containing the ORCID.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": "string"
         },
@@ -1338,6 +1363,7 @@
         },
         "url": {
           "description": "URL with further details on the purity or container.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": [
             "string",
@@ -1544,6 +1570,7 @@
         },
         "url": {
           "description": "DOI (URL) to the publication or dataset.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": "string"
         }

--- a/schemas/expected/source_data.json
+++ b/schemas/expected/source_data.json
@@ -95,6 +95,7 @@
         },
         "url": {
           "description": "URL with further details on the atmospheric setup or control system.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": [
             "string",
@@ -343,6 +344,25 @@
         }
       },
       "title": "Control",
+      "type": "object"
+    },
+    "ControlledOperation": {
+      "additionalProperties": false,
+      "description": "Base class for a controlled operation characterised by one or more quantities, sharing a single control block.",
+      "properties": {
+        "control": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Control"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "How the operation was controlled."
+        }
+      },
+      "title": "ControlledOperation",
       "type": "object"
     },
     "ControlledQuantity": {
@@ -674,6 +694,7 @@
       "properties": {
         "url": {
           "description": "URL to product page or technical documentation.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": [
             "string",
@@ -820,6 +841,7 @@
         },
         "url": {
           "description": "URL to detailed preparation protocol or procedure, such as an article DOI.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": [
             "string",
@@ -875,6 +897,7 @@
         },
         "url": {
           "description": "URL to product specification or datasheet.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": [
             "string",
@@ -1048,6 +1071,7 @@
         },
         "url": {
           "description": "URL to related documentation, publication (DOI), or ELN entry.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": [
             "string",
@@ -1345,6 +1369,7 @@
         },
         "orcid": {
           "description": "An URL containing the ORCID.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": "string"
         },
@@ -1424,6 +1449,7 @@
         },
         "url": {
           "description": "URL with further details on the purity or container.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": [
             "string",
@@ -1630,6 +1656,7 @@
         },
         "url": {
           "description": "DOI (URL) to the publication or dataset.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": "string"
         }

--- a/schemas/expected/svgdigitizer.json
+++ b/schemas/expected/svgdigitizer.json
@@ -123,6 +123,7 @@
         },
         "url": {
           "description": "URL with further details on the atmospheric setup or control system.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": [
             "string",
@@ -373,6 +374,25 @@
       "title": "Control",
       "type": "object"
     },
+    "ControlledOperation": {
+      "additionalProperties": false,
+      "description": "Base class for a controlled operation characterised by one or more quantities, sharing a single control block.",
+      "properties": {
+        "control": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Control"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "How the operation was controlled."
+        }
+      },
+      "title": "ControlledOperation",
+      "type": "object"
+    },
     "ControlledQuantity": {
       "additionalProperties": false,
       "description": "A physical quantity that was actively controlled by an instrument.",
@@ -613,6 +633,7 @@
       "properties": {
         "url": {
           "description": "URL to product page or technical documentation.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": [
             "string",
@@ -759,6 +780,7 @@
         },
         "url": {
           "description": "URL to detailed preparation protocol or procedure, such as an article DOI.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": [
             "string",
@@ -814,6 +836,7 @@
         },
         "url": {
           "description": "URL to product specification or datasheet.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": [
             "string",
@@ -949,6 +972,7 @@
       "properties": {
         "url": {
           "description": "URL to the electronic lab notebook entry.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": "string"
         }
@@ -1003,6 +1027,7 @@
         },
         "url": {
           "description": "URL to related documentation, publication (DOI), or ELN entry.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": [
             "string",
@@ -1266,6 +1291,7 @@
         },
         "orcid": {
           "description": "An URL containing the ORCID.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": "string"
         },
@@ -1313,6 +1339,7 @@
         },
         "url": {
           "description": "URL to project website or information page.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": [
             "string",
@@ -1389,6 +1416,7 @@
         },
         "url": {
           "description": "URL with further details on the purity or container.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": [
             "string",
@@ -1595,6 +1623,7 @@
         },
         "url": {
           "description": "DOI (URL) to the publication or dataset.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": "string"
         }

--- a/schemas/expected/svgdigitizer_package.json
+++ b/schemas/expected/svgdigitizer_package.json
@@ -387,6 +387,7 @@
         },
         "url": {
           "description": "URL or DOI of the source publication.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": [
             "string",

--- a/schemas/minimum_echemdb.json
+++ b/schemas/minimum_echemdb.json
@@ -90,6 +90,7 @@
         },
         "url": {
           "description": "URL with further details on the atmospheric setup or control system.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": [
             "string",
@@ -340,6 +341,25 @@
       "title": "Control",
       "type": "object"
     },
+    "ControlledOperation": {
+      "additionalProperties": false,
+      "description": "Base class for a controlled operation characterised by one or more quantities, sharing a single control block.",
+      "properties": {
+        "control": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Control"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "How the operation was controlled."
+        }
+      },
+      "title": "ControlledOperation",
+      "type": "object"
+    },
     "ControlledQuantity": {
       "additionalProperties": false,
       "description": "A physical quantity that was actively controlled by an instrument.",
@@ -580,6 +600,7 @@
       "properties": {
         "url": {
           "description": "URL to product page or technical documentation.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": [
             "string",
@@ -726,6 +747,7 @@
         },
         "url": {
           "description": "URL to detailed preparation protocol or procedure, such as an article DOI.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": [
             "string",
@@ -781,6 +803,7 @@
         },
         "url": {
           "description": "URL to product specification or datasheet.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": [
             "string",
@@ -954,6 +977,7 @@
         },
         "url": {
           "description": "URL to related documentation, publication (DOI), or ELN entry.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": [
             "string",
@@ -1259,6 +1283,7 @@
         },
         "orcid": {
           "description": "An URL containing the ORCID.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": "string"
         },
@@ -1338,6 +1363,7 @@
         },
         "url": {
           "description": "URL with further details on the purity or container.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": [
             "string",
@@ -1544,6 +1570,7 @@
         },
         "url": {
           "description": "DOI (URL) to the publication or dataset.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": "string"
         }

--- a/schemas/source_data.json
+++ b/schemas/source_data.json
@@ -95,6 +95,7 @@
         },
         "url": {
           "description": "URL with further details on the atmospheric setup or control system.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": [
             "string",
@@ -343,6 +344,25 @@
         }
       },
       "title": "Control",
+      "type": "object"
+    },
+    "ControlledOperation": {
+      "additionalProperties": false,
+      "description": "Base class for a controlled operation characterised by one or more quantities, sharing a single control block.",
+      "properties": {
+        "control": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Control"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "How the operation was controlled."
+        }
+      },
+      "title": "ControlledOperation",
       "type": "object"
     },
     "ControlledQuantity": {
@@ -674,6 +694,7 @@
       "properties": {
         "url": {
           "description": "URL to product page or technical documentation.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": [
             "string",
@@ -820,6 +841,7 @@
         },
         "url": {
           "description": "URL to detailed preparation protocol or procedure, such as an article DOI.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": [
             "string",
@@ -875,6 +897,7 @@
         },
         "url": {
           "description": "URL to product specification or datasheet.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": [
             "string",
@@ -1048,6 +1071,7 @@
         },
         "url": {
           "description": "URL to related documentation, publication (DOI), or ELN entry.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": [
             "string",
@@ -1345,6 +1369,7 @@
         },
         "orcid": {
           "description": "An URL containing the ORCID.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": "string"
         },
@@ -1424,6 +1449,7 @@
         },
         "url": {
           "description": "URL with further details on the purity or container.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": [
             "string",
@@ -1630,6 +1656,7 @@
         },
         "url": {
           "description": "DOI (URL) to the publication or dataset.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": "string"
         }

--- a/schemas/svgdigitizer.json
+++ b/schemas/svgdigitizer.json
@@ -123,6 +123,7 @@
         },
         "url": {
           "description": "URL with further details on the atmospheric setup or control system.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": [
             "string",
@@ -373,6 +374,25 @@
       "title": "Control",
       "type": "object"
     },
+    "ControlledOperation": {
+      "additionalProperties": false,
+      "description": "Base class for a controlled operation characterised by one or more quantities, sharing a single control block.",
+      "properties": {
+        "control": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Control"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "How the operation was controlled."
+        }
+      },
+      "title": "ControlledOperation",
+      "type": "object"
+    },
     "ControlledQuantity": {
       "additionalProperties": false,
       "description": "A physical quantity that was actively controlled by an instrument.",
@@ -613,6 +633,7 @@
       "properties": {
         "url": {
           "description": "URL to product page or technical documentation.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": [
             "string",
@@ -759,6 +780,7 @@
         },
         "url": {
           "description": "URL to detailed preparation protocol or procedure, such as an article DOI.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": [
             "string",
@@ -814,6 +836,7 @@
         },
         "url": {
           "description": "URL to product specification or datasheet.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": [
             "string",
@@ -949,6 +972,7 @@
       "properties": {
         "url": {
           "description": "URL to the electronic lab notebook entry.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": "string"
         }
@@ -1003,6 +1027,7 @@
         },
         "url": {
           "description": "URL to related documentation, publication (DOI), or ELN entry.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": [
             "string",
@@ -1266,6 +1291,7 @@
         },
         "orcid": {
           "description": "An URL containing the ORCID.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": "string"
         },
@@ -1313,6 +1339,7 @@
         },
         "url": {
           "description": "URL to project website or information page.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": [
             "string",
@@ -1389,6 +1416,7 @@
         },
         "url": {
           "description": "URL with further details on the purity or container.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": [
             "string",
@@ -1595,6 +1623,7 @@
         },
         "url": {
           "description": "DOI (URL) to the publication or dataset.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": "string"
         }

--- a/schemas/svgdigitizer_package.json
+++ b/schemas/svgdigitizer_package.json
@@ -387,6 +387,7 @@
         },
         "url": {
           "description": "URL or DOI of the source publication.",
+          "format": "uri",
           "pattern": "^https?://.*$",
           "type": [
             "string",


### PR DESCRIPTION
linkml <1.11 pins click <8.2, which conflicts with environments where the conda solve picks a newer click (e.g. 8.3+), making mdstools uninstallable as a pypi dependency alongside conda packages.

linkml 1.11 requires click >=8.2 and linkml-runtime >=1.10, so bump both pins. All tests pass and generated schemas are unchanged.